### PR TITLE
Remove retain cycles on dataSource and delegate properties

### DIFF
--- a/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
+++ b/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
@@ -25,7 +25,7 @@ extension UIViewController {
      */
     public weak var emptyStateDataSource: UIEmptyStateDataSource? {
         get { return objc_getAssociatedObject(self, &Keys.emptyStateDataSource)  as? UIEmptyStateDataSource }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDataSource, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        set { objc_setAssociatedObject(self, &Keys.emptyStateDataSource, newValue, .OBJC_ASSOCIATION_ASSIGN) }
     }
     
     /**
@@ -36,7 +36,7 @@ extension UIViewController {
      */
     public weak var emptyStateDelegate: UIEmptyStateDelegate? {
         get { return objc_getAssociatedObject(self, &Keys.emptyStateDelegate) as? UIEmptyStateDelegate }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDelegate, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        set { objc_setAssociatedObject(self, &Keys.emptyStateDelegate, newValue, .OBJC_ASSOCIATION_ASSIGN) }
     }
     
     /**

--- a/Example/UIEmptyStateExample/Base.lproj/Main.storyboard
+++ b/Example/UIEmptyStateExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="esM-qG-LMq">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="esM-qG-LMq">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -97,7 +97,7 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cWS-t8-6Lq" id="DZb-IG-AgU">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -108,6 +108,11 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="zZ5-eQ-y1i">
+                        <barButtonItem key="leftBarButtonItem" title="Item" id="10o-R4-HvR">
+                            <connections>
+                                <segue destination="kbe-jJ-3b3" kind="show" id="a6r-rQ-x06"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="9kI-gT-EaW">
                             <connections>
                                 <action selector="addButtonTapped:" destination="vSC-f6-lHL" id="84X-LA-qDh"/>
@@ -126,7 +131,7 @@
                     <tabBarItem key="tabBarItem" title="TableView" id="Lt9-sa-eBh"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="D33-UI-bYf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -145,7 +150,7 @@
                     <tabBarItem key="tabBarItem" title="CollectionView" id="Skv-cg-X07"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="R5r-uK-PCo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -156,6 +161,41 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sIM-f4-gcW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="960.79999999999995" y="553.67316341829087"/>
+        </scene>
+        <!--UITableView Controller-->
+        <scene sceneID="nIc-Oi-I6M">
+            <objects>
+                <tableViewController title="UITableView Controller" id="kbe-jJ-3b3" customClass="EmptyStateTableViewController" customModule="UIEmptyStateExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="rmm-XK-GUh">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="exampleCell" id="cIK-BL-HFe">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cIK-BL-HFe" id="a64-nM-Tod">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="kbe-jJ-3b3" id="ZVR-XX-PK5"/>
+                            <outlet property="delegate" destination="kbe-jJ-3b3" id="cW5-UC-A3c"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="pkf-FN-GnK">
+                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="JqR-LO-6hO">
+                            <connections>
+                                <action selector="addButtonTapped:" destination="kbe-jJ-3b3" id="Fvs-4E-iZc"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="h5a-Yk-jaz" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2582" y="-124"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
Changed `objc_AssociationPolicy` in `emptyStateDataSource` and `emptyStateDelegate` associatedObject setters to `.OBJC_ASSOCIATION_ASSIGN` from `.OBJC_ASSOCIATION_RETAIN`. 

This will ensure that `UIEmptyStateDataSource` and `UIEmptyStateDataSource` implementations are stored as weak references and no longer cause retain cycles in UIViewControllers using default delegate and data source implementations.