### PR TITLE
Remove retain cycles on dataSource and delegate properties

### DIFF
--- a/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
+++ b/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
@@ -25,7 +25,7 @@ extension UIViewController {
      */
     public weak var emptyStateDataSource: UIEmptyStateDataSource? {
         get { return objc_getAssociatedObject(self, &Keys.emptyStateDataSource)  as? UIEmptyStateDataSource }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDataSource, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        set { objc_setAssociatedObject(self, &Keys.emptyStateDataSource, newValue, .OBJC_ASSOCIATION_ASSIGN) }
     }
     
     /**
@@ -36,7 +36,7 @@ extension UIViewController {
      */
     public weak var emptyStateDelegate: UIEmptyStateDelegate? {
         get { return objc_getAssociatedObject(self, &Keys.emptyStateDelegate) as? UIEmptyStateDelegate }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDelegate, newValue, .OBJC_ASSOCIATION_RETAIN) }
+        set { objc_setAssociatedObject(self, &Keys.emptyStateDelegate, newValue, .OBJC_ASSOCIATION_ASSIGN) }
     }
     
     /**

--- a/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
+++ b/Example/Pods/UIEmptyState/UIEmptyState/UIViewController+UIEmptyState.swift
@@ -17,6 +17,11 @@ extension UIViewController {
         static var emptyStateDelegate = "com.luispadron.emptyStateDelegate"
     }
     
+    /// Container for safely storing weak references
+    private struct WeakObjectContainer {
+        private(set) weak var object: AnyObject?
+    }
+    
     /**
      The data source for the Empty View
      
@@ -24,19 +29,31 @@ extension UIViewController {
      however feel free to implement these methods to customize your view.
      */
     public weak var emptyStateDataSource: UIEmptyStateDataSource? {
-        get { return objc_getAssociatedObject(self, &Keys.emptyStateDataSource)  as? UIEmptyStateDataSource }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDataSource, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+        get {
+            let container = objc_getAssociatedObject(self, &Keys.emptyStateDataSource) as? WeakObjectContainer
+            return container?.object as? UIEmptyStateDataSource
+        }
+        set {
+            let container = WeakObjectContainer(object: newValue)
+            objc_setAssociatedObject(self, &Keys.emptyStateDataSource, container, .OBJC_ASSOCIATION_RETAIN)
+        }
     }
-    
+
     /**
      The delegate for UIEmptyStateView
-     
+
      **Important:** this delegate and its functions are only used when using UIEmptyStateView.
      If you will provide a custom view in the UIEmptyStateDataSource you must handle how this delegate operates
      */
     public weak var emptyStateDelegate: UIEmptyStateDelegate? {
-        get { return objc_getAssociatedObject(self, &Keys.emptyStateDelegate) as? UIEmptyStateDelegate }
-        set { objc_setAssociatedObject(self, &Keys.emptyStateDelegate, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+        get {
+            let container = objc_getAssociatedObject(self, &Keys.emptyStateDelegate) as? WeakObjectContainer
+            return container?.object as? UIEmptyStateDelegate
+        }
+        set {
+            let container = WeakObjectContainer(object: newValue)
+            objc_setAssociatedObject(self, &Keys.emptyStateDelegate, container, .OBJC_ASSOCIATION_RETAIN)
+        }
     }
     
     /**


### PR DESCRIPTION
Changed `objc_AssociationPolicy` in `emptyStateDataSource` and `emptyStateDelegate` associatedObject setters to `.OBJC_ASSOCIATION_ASSIGN` from `.OBJC_ASSOCIATION_RETAIN`. 

This will ensure that `UIEmptyStateDataSource` and `UIEmptyStateDataSource` implementations are stored as weak references and no longer cause retain cycles in UIViewControllers using default delegate and data source implementations.

I am opening another pull request because last one contained unnecessary change and also I done goofed with updating previous pull request ¯\\\_(ツ)\_/¯