### PR TITLE
Specify the Swift version in the podspec

### DIFF
--- a/UIEmptyState.podspec
+++ b/UIEmptyState.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/luispadron/UIEmptyState.git", :tag => "v#{s.version}" }
   s.source_files  = "src/UIEmptyState", "src/UIEmptyState/**/*.{h,m}"
+  s.swift_version = "4.1"
 end
 


### PR DESCRIPTION
This fixes some errors building in Xcode 10 where some things have been renamed in Swift 4.2.