### PR TITLE
fix(ios14): red background appears

### DIFF
--- a/src/UIEmptyState/UIEmptyStateView.swift
+++ b/src/UIEmptyState/UIEmptyStateView.swift
@@ -253,7 +253,7 @@ open class UIEmptyStateView: UIView {
         contentView.axis = .vertical
         contentView.distribution = .equalSpacing
         contentView.alignment = .center
-        contentView.backgroundColor = UIColor.red
+        contentView.backgroundColor = UIColor.clear
         contentView.spacing = spacing ?? 0
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addArrangedSubview(titleLabel)


### PR DESCRIPTION
When using default `UIStackView` on iOS14, background is solid red. I don't know why this issue is not present under lower iOS versions though.